### PR TITLE
Replaced parameter kernel.root_dir with kernel.project_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ This changelog references the relevant changes (bug and security fixes).
 -----
 
   * Dropped support for php 5.x
-    * Updated travis config
+  * Updated travis config
   * Dropped support for Symfony 2.x
   * Dropped support for Twig 1.x
   * Updated testsuite to phpunit ^8.4 
-    * Updated phpunit config to [best practices](https://thephp.cc/dates/2019/11/symfonycon/phpunit-best-practices) (slide 52)
+  * Updated phpunit config to [best practices](https://thephp.cc/dates/2019/11/symfonycon/phpunit-best-practices) (slide 52)
   * Added compatibility for Symfony 5.x
   * Added compatibility for Twig 3.x
+  * Replaced parameter kernel.root_dir with kernel.project_dir
 
 1.2.0
 -----

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,7 +43,7 @@ class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('web_dir')
-                    ->example('%kernel.root_dir%/../web')
+                    ->example('%kernel.project_dir%/web')
                     ->cannotBeEmpty()
                 ->end()
             ->end();

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All configuration options, with default values:
 fh_webpack:
     stats_filename: stats.json
     # web/document root, assets will be referenced from this path
-    web_dir: '%kernel.root_dir%/../web'
+    web_dir: '%kernel.project_dir%/web'
 ```
 
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,5 @@
 parameters:
-    fh_webpack.web_dir: '%kernel.root_dir%/../web'
+    fh_webpack.web_dir: '%kernel.project_dir%/web'
     fh_webpack.stats_filename: 'stats.json'
 
 services:


### PR DESCRIPTION
Support from Symfony 3.3:
https://symfony.com/blog/new-in-symfony-3-3-a-simpler-way-to-get-the-project-root-directory