### PR TITLE
Twig functie "webpack_asset_contents" toegevoegd

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,19 @@ fh_webpack:
 Usage
 -----
 
+### Link webpack files
+
 ```jinja
 <link rel="stylesheet" href="{{ webpack_asset('assets/frontend/build', 'app', 'css') }}" />
 <script type="text/javascript" src="{{ webpack_asset('assets/frontend/build', 'app', 'js') }}"></script>
+```
+
+### Dump the contents of a webpack file
+
+```jinja
+<style type="text/css">
+    {{ webpack_asset_contents('assets/frontend/build', 'email', 'css')|raw }}
+</style>
 ```
 
 Requirements

--- a/Templating/WebpackHelper.php
+++ b/Templating/WebpackHelper.php
@@ -69,6 +69,12 @@ class WebpackHelper extends Helper
         );
     }
 
+    public function getAssetsPath(string $path, string $name, string $extension = 'js'): string
+    {
+        $assetUrl = $this->getAssetUrl($path, $name, $extension);
+        return rtrim($this->webDir, '/') . $assetUrl;
+    }
+
     public function getName(): string
     {
         return 'fh_webpack';

--- a/Tests/Templating/WebpackHelperTest.php
+++ b/Tests/Templating/WebpackHelperTest.php
@@ -55,4 +55,10 @@ final class WebpackHelperTest extends TestCase
 
         $this->helper->getAssetUrl('', 'xuifysdiufysdifysdifysdi');
     }
+
+    public function testAssetsPathIsFound(): void
+    {
+        $path = $this->helper->getAssetsPath('', 'font', 'woff2');
+        $this->assertStringContainsString('/Tests/Templating/web/font.90afa358faca7496fd211daa167dcb46.woff2', $path);
+    }
 }

--- a/Twig/WebpackExtension.php
+++ b/Twig/WebpackExtension.php
@@ -34,7 +34,8 @@ class WebpackExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('webpack_asset', [$this, 'getAssetUrl'])
+            new TwigFunction('webpack_asset', [$this, 'getAssetUrl']),
+            new TwigFunction('webpack_asset_contents', [$this, 'getAssetContents']),
         ];
     }
 
@@ -45,5 +46,18 @@ class WebpackExtension extends AbstractExtension
                 $this->webpackHelper->getAssetUrl($path, $chunkName, $extension),
                 $packageName
             );
+    }
+
+    public function getAssetContents($path, $chunkName, $extension = 'js'): string
+    {
+        $assetsPath = $this->webpackHelper->getAssetsPath($path, $chunkName, $extension);
+
+        if (!file_exists($assetsPath) || !is_readable($assetsPath)) {
+            throw new \RuntimeException(
+                sprintf('Asset with name "%s" could not be found or is not readable.', $chunkName)
+            );
+        }
+
+        return file_get_contents($assetsPath);
     }
 }


### PR DESCRIPTION
In Roan wordt bijvoorbeeld het volgende gebruikt in de base mail template:

```
<style type="text/css">
    {{ file_get_contents(absolute_url(webpack_asset('assets/frontend/build', 'email', 'css')))|raw }}
</style>
```

Dit werkt niet goed met Symfony local webserver omdat deze een proxy gebruikt en PHP niet direct de proxy kan benaderen via file_get_contents (zonder speciale setup). Om dit op te lossen haal ik nu de file contents op met behulp van het path ipv van de url. Deze functionaliteit is in een nieuwe Twig functie "webpack_asset_contents" gezet. Dit kan wellicht ook handig zijn voor bijvoorbeeld het embedden van SVG's. De bovenstaande code kan nu vervangen worden door:

```
<style type="text/css">
    {{ webpack_asset_contents('assets/frontend/build', 'email', 'css')|raw }}
</style>
```